### PR TITLE
Feat: todo리스트 데이터베이스 저장

### DIFF
--- a/react/protoInbodyReact-main/src/Component/FoodSearchR.js
+++ b/react/protoInbodyReact-main/src/Component/FoodSearchR.js
@@ -5,13 +5,17 @@ import config from "../config";
 export default function FoodSearchR() {
   const [data, setData] = useState(null);
   const [foodNm, setFoodNm] = useState("");
+  const [selectedDate, setSelectedDate] = useState(""); // 날짜 선택
+  const [dietMemo, setDietMemo] = useState(""); // 메모 입력
   const userid = sessionStorage.getItem("userid");
   const navigate = useNavigate();
 
+  // 뒤로가기 버튼 (임시)
   const navigateToFood = () => {
     navigate("/todo");
   };
 
+  // 음식 검색 API 호출
   const fetchData = () => {
     if (foodNm) {
       fetch(`http://${config.SERVER_URL}/request/foodname/${foodNm}`)
@@ -21,24 +25,55 @@ export default function FoodSearchR() {
     }
   };
 
+  // 음식 선택 후 저장 API 호출
   const handleButtonClick = (item) => {
-    console.log(item);
-    const itemWithUserId = { ...item, userid };
+    if (!selectedDate) {
+        alert("날짜를 선택하세요!");
+        return;
+    }
 
-    fetch(`http://${config.SERVER_URL}/upload/recordfood`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(itemWithUserId),
+    const foodData = {
+        ...item,
+        userid: sessionStorage.getItem("userid") || "default_user",  // 유저 ID 기본값 설정
+        timestamp: selectedDate || new Date().toISOString(),         // 선택한 날짜가 없으면 현재 날짜
+        dietMemo: dietMemo || "메모 없음"                           // 메모 기본값 설정
+    };
+
+    console.log("전송할 데이터:", foodData); // 전송 전에 확인
+
+    fetch(`http://${config.SERVER_URL}/request/saveFoodRecord`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(foodData),
     })
-      .then((response) => response.json())
-      .then((data) => console.log("Success:", data))
+      .then((response) => response.text()) // JSON 형식이 아니라면 .json() 대신 .text() 사용
+      .then((data) => {
+          console.log("서버 응답:", data);
+          alert(data);  // 성공 메시지 출력
+      })
       .catch((error) => console.error("Error:", error));
   };
 
   return (
     <div>
+      <h2>날짜 선택</h2>
+      <input
+        type="date"
+        value={selectedDate}
+        onChange={(e) => setSelectedDate(e.target.value)}
+      />
+
+      <h2>메모 입력</h2>
+      <input
+        type="text"
+        placeholder="메모 입력"
+        value={dietMemo}
+        onChange={(e) => setDietMemo(e.target.value)}
+      />
+
+      <h2>음식 검색</h2>
       <input
         type="text"
         value={foodNm}

--- a/react/protoInbodyReact-main/src/config.js
+++ b/react/protoInbodyReact-main/src/config.js
@@ -1,5 +1,5 @@
 const config = {
-  SERVER_URL: "172.30.113.136:8080",
+  SERVER_URL: "ip:8080",
 };
 
 export default config;

--- a/spring/protoInbody-main/src/main/java/com/example/demo/DTO/FoodDto.java
+++ b/spring/protoInbody-main/src/main/java/com/example/demo/DTO/FoodDto.java
@@ -1,6 +1,7 @@
 package com.example.demo.DTO;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Date;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class FoodDto {
@@ -13,12 +14,14 @@ public class FoodDto {
     private double chocdf;
     private double foodSize;
     private String userid;
+    private String dietMemo;  // 추가된 필드
+    private Date timestamp;   // 추가된 필드
 
     public FoodDto() {
     }
 
-    public FoodDto(String foodNm, String mfrNm, double enerc, double prot, double fatce, double chocdf, double foodSize,
-            String userid) {
+    public FoodDto(String foodNm, String mfrNm, double enerc, double prot, double fatce, double chocdf,
+                   double foodSize, String userid, String dietMemo, Date timestamp) {
         this.foodNm = foodNm;
         this.mfrNm = mfrNm;
         this.enerc = enerc;
@@ -27,6 +30,8 @@ public class FoodDto {
         this.chocdf = chocdf;
         this.foodSize = foodSize;
         this.userid = userid;
+        this.dietMemo = dietMemo;
+        this.timestamp = timestamp;
     }
 
     public String getFoodNm() {
@@ -93,10 +98,26 @@ public class FoodDto {
         this.userid = userid;
     }
 
-    @Override
-    public String toString() {
-        return "FoodDto [foodNm=" + foodNm + ", mfrNm=" + mfrNm + ", enerc=" + enerc + ", prot=" + prot + ", fatce="
-                + fatce + ", chocdf=" + chocdf + ", foodSize=" + foodSize + ", userid=" + userid + "]";
+    public String getDietMemo() {
+        return dietMemo;
     }
 
+    public void setDietMemo(String dietMemo) {
+        this.dietMemo = dietMemo;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Date timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "FoodDto [foodNm=" + foodNm + ", mfrNm=" + mfrNm + ", enerc=" + enerc + ", prot=" + prot +
+                ", fatce=" + fatce + ", chocdf=" + chocdf + ", foodSize=" + foodSize +
+                ", userid=" + userid + ", dietMemo=" + dietMemo + ", timestamp=" + timestamp + "]";
+    }
 }

--- a/spring/protoInbody-main/src/main/java/com/example/demo/Entity/DietRecord.java
+++ b/spring/protoInbody-main/src/main/java/com/example/demo/Entity/DietRecord.java
@@ -1,9 +1,9 @@
 package com.example.demo.Entity;
 
 import java.util.Date;
-
 import jakarta.persistence.*;
 
+@Entity
 public class DietRecord {
 
     @Id
@@ -29,11 +29,14 @@ public class DietRecord {
     @Column(nullable = false)
     private double totalfat;
 
+    @Column(nullable = true)
+    private String dietMemo;  // diet_memo 필드 추가
+
     public DietRecord() {
     }
 
     public DietRecord(Long id, UserInfo userInfo, Date timestamp, double totalcalori, double totalcarbs,
-            double totalprotein, double totalfat) {
+                      double totalprotein, double totalfat, String dietMemo) {
         this.id = id;
         this.userInfo = userInfo;
         this.timestamp = timestamp;
@@ -41,6 +44,7 @@ public class DietRecord {
         this.totalcarbs = totalcarbs;
         this.totalprotein = totalprotein;
         this.totalfat = totalfat;
+        this.dietMemo = dietMemo;
     }
 
     public Long getId() {
@@ -99,4 +103,11 @@ public class DietRecord {
         this.totalfat = totalfat;
     }
 
+    public String getDietMemo() {
+        return dietMemo;
+    }
+
+    public void setDietMemo(String dietMemo) {
+        this.dietMemo = dietMemo;
+    }
 }

--- a/spring/protoInbody-main/src/main/java/com/example/demo/Repo/RepoDietRecord.java
+++ b/spring/protoInbody-main/src/main/java/com/example/demo/Repo/RepoDietRecord.java
@@ -1,0 +1,9 @@
+package com.example.demo.Repo;
+
+import com.example.demo.Entity.DietRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RepoDietRecord extends JpaRepository<DietRecord, Long> {
+}

--- a/spring/protoInbody-main/src/main/java/com/example/demo/Repo/RepoUserInfo.java
+++ b/spring/protoInbody-main/src/main/java/com/example/demo/Repo/RepoUserInfo.java
@@ -17,4 +17,5 @@ public interface RepoUserInfo extends JpaRepository<UserInfo, Long> {
     // 성별 조회 메서드 추가
     @Query("SELECT u.sex FROM UserInfo u WHERE u.userid = :userid")
     Integer getUserSexById(@Param("userid") String userid);
+
 }

--- a/spring/protoInbody-main/src/main/java/com/example/demo/Service/FoodService.java
+++ b/spring/protoInbody-main/src/main/java/com/example/demo/Service/FoodService.java
@@ -81,7 +81,8 @@ public class FoodService {
                     double chocdf = itemNode.path("chocdf").asDouble();
                     double foodSize = itemNode.path("foodSize").asDouble();
 
-                    FoodDto foodDto = new FoodDto(foodNm, mfrNm, enerc, prot, fatce, chocdf, foodSize, null);
+                    // API에서 음식정보만 가져와 FoodDto 리스트에 반환후 리액트에서 dietMemo와 timestamp을 추가해서 백엔드로 전송함
+                    FoodDto foodDto = new FoodDto(foodNm, mfrNm, enerc, prot, fatce, chocdf, foodSize, null, null, null);
                     foodDetailsList.add(foodDto);
                 }
             }


### PR DESCRIPTION
/food에서 날짜 선택, 메모 입력 후 음식 검색 & 저장 기능 추가 (dietMemo, timestamp 포함)

- /food 페이지에서 날짜 선택 & 메모 입력 가능하도록 수정
- 음식 검색 후 버튼 클릭 시 `dietMemo`, `timestamp`을 추가하여 API 요청
- `FoodSearchR.js`에서 선택한 데이터가 `FoodDto`와 함께 백엔드로 전송됨
- 백엔드에서 `saveFoodRecord` API가 `dietMemo`, `timestamp`을 받아 `DietRecord`에 저장하도록 수정"