### PR TITLE
feat: JWT 인증 강화, XSS 방지 및 CORS 설정 수정

### DIFF
--- a/react/protoInbodyReact-main/src/Component/Login.js
+++ b/react/protoInbodyReact-main/src/Component/Login.js
@@ -24,6 +24,7 @@ export default function Login() {
           headers: {
             "Content-Type": "application/json",
           },
+          credentials: "include",
           body: JSON.stringify(userInfo),
         }
       );
@@ -32,10 +33,9 @@ export default function Login() {
         const data = await response.json();
 
         console.log("Login successful");
-        sessionStorage.setItem("token", data.jwt); // JWT 토큰 저장
-        sessionStorage.setItem("userid", userid); // 로그인한 사용자 정보 저장
 
         alert("로그인 성공!");
+        sessionStorage.setItem("userid", userid); 
         navigate("/main"); //메인 페이지 이동
         // 성공 시 추가적인 로직 (예: 리다이렉트)
       } else {

--- a/react/protoInbodyReact-main/src/Component/Main.js
+++ b/react/protoInbodyReact-main/src/Component/Main.js
@@ -1,56 +1,62 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import config from "../config";
 
 export default function Main() {
-  const userid = sessionStorage.getItem("userid");
-  const token = sessionStorage.getItem("token");
-
   const navigate = useNavigate();
   const [bodyrecod, setBodyRecod] = useState([]);
   const [loading, setLoading] = useState(true);
+  const useridRef = useRef(sessionStorage.getItem("userid"));
 
-  const navigateToRecordBody = () => {
-    navigate("/recordbody");
+  const navigateToRecordBody = () => navigate("/recordbody");
+  const navigateToRank = () => navigate("/rank");
+  const navigateToTodo = () => navigate("/todo");
+
+  // 로그아웃 처리
+  const handleLogout = async () => {
+    await fetch(`http://${config.SERVER_URL}/request/logout`, {
+      method: "POST",
+      credentials: "include",
+    });
+
+    sessionStorage.removeItem("userid");
+    navigate("/login");
   };
 
-  const navigateToRank = () => {
-    navigate("/rank");
-  };
-  const navigateToTodo = () => {
-    navigate("/todo");
-  };
-  const handleLogout = () => {
-    sessionStorage.removeItem("userid"); // 로그아웃 시 사용자 정보 삭제
-    sessionStorage.removeItem("token"); // 로그아웃 시 사용자 정보 삭제
-
-    navigate("/login"); // 로그인 페이지로 이동
-  };
-
+  // 로그인 상태 확인 후 `userid` 가져오기
   useEffect(() => {
-    if (!token || !userid) {
-      navigate("/login"); // 로그인 안 했으면 로그인 페이지로 강제 이동
-      return;
-    }
-
-    fetch(`http://${config.SERVER_URL}/download/recentuserbody/${userid}`, {
+    fetch(`http://${config.SERVER_URL}/request/validate`, {
       method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`, // JWT 토큰을 Authorization 헤더에 포함
-      },
+      credentials: "include", // 쿠키 자동 포함
     })
-      .then((response) => response.json())
+      .then((response) => {
+        if (!response.ok) throw new Error("Unauthorized");
+        return response.json();
+      })
       .then((data) => {
-        setBodyRecod(data);
+        console.log("로그인 상태 확인 성공:", data);
+        useridRef.current = data.userid;
+        sessionStorage.setItem("userid", data.userid);
+
+        // 사용자 신체 기록 가져오기
+        return fetch(`http://${config.SERVER_URL}/download/recentuserbody/${data.userid}`, {
+          method: "GET",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+        });
+      })
+      .then((response) => response.json())
+      .then((bodyData) => {
+        console.log("신체 기록 응답 데이터:", bodyData);
+        setBodyRecod(bodyData);
         setLoading(false);
       })
-      .catch((error) => {
-        console.error("Error fetching users:", error);
-        setLoading(false);
+      .catch(() => {
+        console.warn("인증 실패. 로그인 페이지로 이동");
+        sessionStorage.removeItem("userid");
+        navigate("/login");
       });
-  }, [userid, token, navigate]);
-
-  console.log(bodyrecod, "여기여");
+  }, [navigate]);
 
   if (loading) {
     return <p>📡 데이터를 불러오는 중입니다...</p>; // 로딩 중 메시지 유지
@@ -70,40 +76,25 @@ export default function Main() {
 
   return (
     <div>
-      {userid ? (
+      {useridRef.current ? (
         <>
           <h2>Main Screen</h2>
           <p>Welcome to the main screen!</p>
-          <p>Logged in as: {userid}</p>
+          <p>Logged in as: {useridRef.current}</p>
 
           <div>
             <h2>📊 InBody 결과</h2>
-            <p>
-              <strong>📏 키:</strong> {bodyrecod[0].height} cm
-            </p>
-            <p>
-              <strong>⚖️ 몸무게:</strong> {bodyrecod[0].weight} kg
-            </p>
-            <p>
-              <strong>📉 체지방률:</strong> {bodyrecod[0].fatpercentage} %
-            </p>
-            <p>
-              <strong>💪 BMI:</strong> {bodyrecod[0].bmi}
-            </p>
-            <p>
-              <strong>🔥 InBody Score:</strong> {bodyrecod[0].inbodyScore}
-            </p>
+            <p><strong>📏 키:</strong> {bodyrecod[0].height} cm</p>
+            <p><strong>⚖️ 몸무게:</strong> {bodyrecod[0].weight} kg</p>
+            <p><strong>📉 체지방률:</strong> {bodyrecod[0].fatpercentage} %</p>
+            <p><strong>💪 BMI:</strong> {bodyrecod[0].bmi}</p>
+            <p><strong>🔥 InBody Score:</strong> {bodyrecod[0].inbodyScore}</p>
           </div>
 
-          <button onClick={navigateToRank} style={{ marginLeft: "10px" }}>
-            점수 랭킹 보기
-          </button>
-
+          <button onClick={navigateToRank} style={{ marginLeft: "10px" }}>점수 랭킹 보기</button>
           <button onClick={navigateToRecordBody}>신체 정보 입력</button>
           <button onClick={navigateToTodo}>음식 다이어리</button>
-          <button onClick={handleLogout} style={{ marginLeft: "10px" }}>
-            로그아웃
-          </button>
+          <button onClick={handleLogout} style={{ marginLeft: "10px" }}>로그아웃</button>
         </>
       ) : (
         <p>잘못된 접근</p>

--- a/react/protoInbodyReact-main/src/Component/RankPage.js
+++ b/react/protoInbodyReact-main/src/Component/RankPage.js
@@ -6,14 +6,14 @@ export default function RankPage() {
   const [femaleRank, setFemaleRank] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const token = sessionStorage.getItem("token");
 
   useEffect(() => {
     // 남성 랭킹 조회
     fetch(`http://${config.SERVER_URL}/download/scorerankmale`, {
       method: "GET",
+      credentials: "include", // 쿠키 포함 요청
       headers: {
-        Authorization: `Bearer ${token}`, // JWT 토큰을 Authorization 헤더에 포함
+        "Content-Type": "application/json",
       },
     })
       .then((res) => {
@@ -27,17 +27,17 @@ export default function RankPage() {
         console.error("남성 랭킹 조회 오류:", error);
         setError(error.message);
       });
+
     // 여성 랭킹 조회
     fetch(`http://${config.SERVER_URL}/download/scorerankfemale`, {
       method: "GET",
+      credentials: "include", // 쿠키 포함 요청
       headers: {
-        Authorization: `Bearer ${token}`, // JWT 토큰을 Authorization 헤더에 포함
+        "Content-Type": "application/json",
       },
     })
       .then((res) => {
-        if (!res.ok) {
-          throw new Error("서버 응답 오류 (여성 랭킹)");
-        }
+        if (!res.ok) throw new Error("서버 응답 오류 (여성 랭킹)");
         return res.json();
       })
       .then((data) => setFemaleRank(data))
@@ -55,10 +55,6 @@ export default function RankPage() {
   if (error) {
     return <p>⚠️ 오류 발생: {error}</p>;
   }
-
-  console.log(maleRank, "여긴남자");
-
-  console.log(femaleRank, "여긴 여자");
 
   return (
     <div>

--- a/react/protoInbodyReact-main/src/Component/RecordBody.js
+++ b/react/protoInbodyReact-main/src/Component/RecordBody.js
@@ -1,22 +1,40 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import config from "../config";
 
 export default function RecordBody() {
-  const [userid] = useState(sessionStorage.getItem("userid"));
+  const navigate = useNavigate();
+  const [userid, setUserid] = useState("");
+
   const [height, setHeight] = useState("");
   const [weight, setWeight] = useState("");
   const [fatpercentage, setFatPercentage] = useState("");
-  const [bmi, setBmi] = useState(null);
-  const [inbodyScore, setInbodyScore] = useState(null);
-  const navigate = useNavigate();
-  const token = sessionStorage.getItem("token");
+
+  useEffect(() => {
+    // 현재 로그인된 유저 확인
+    fetch(`http://${config.SERVER_URL}/request/validate`, {
+      method: "GET",
+      credentials: "include",
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error("Unauthorized");
+        return response.json();
+      })
+      .then((data) => {
+        console.log("로그인 확인 성공:", data);
+        setUserid(data.userid);
+      })
+      .catch(() => {
+        console.warn("인증 실패. 로그인 페이지로 이동");
+        navigate("/login");
+      });
+  }, [navigate]);
 
   const handleSubmit = async (event) => {
     event.preventDefault();
 
     const userBodyInfo = {
-      userid: userid,
+      userid,
       height: parseFloat(height),
       weight: parseFloat(weight),
       fatpercentage: parseFloat(fatpercentage),
@@ -25,26 +43,16 @@ export default function RecordBody() {
     console.log("📌 보내는 데이터:", userBodyInfo);
 
     try {
-      const response = await fetch(
-        `http://${config.SERVER_URL}/upload/recorduserbody`,
-
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`, // JWT 토큰 추가
-          },
-          body: JSON.stringify(userBodyInfo),
-        }
-      );
+      const response = await fetch(`http://${config.SERVER_URL}/upload/recorduserbody`, {
+        method: "POST",
+        credentials: "include", // 쿠키 포함 요청
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(userBodyInfo),
+      });
 
       if (response.ok) {
-        const responseData = await response.json();
-        console.log("📌 서버 응답 데이터:", responseData);
-
-        setBmi(responseData.bmi);
-        setInbodyScore(responseData.inbodyScore);
-
         alert("신체 정보가 저장되었습니다! 메인 페이지로 이동합니다.");
         navigate("/main");
       } else {
@@ -62,58 +70,18 @@ export default function RecordBody() {
       <form onSubmit={handleSubmit}>
         <div>
           <label>📏 Height (cm):</label>
-          <input
-            type="number"
-            step="0.1"
-            value={height}
-            onChange={(e) => setHeight(e.target.value)}
-            required
-          />
+          <input type="number" step="0.1" value={height} onChange={(e) => setHeight(e.target.value)} required />
         </div>
         <div>
           <label>⚖️ Weight (kg):</label>
-          <input
-            type="number"
-            step="0.1"
-            value={weight}
-            onChange={(e) => setWeight(e.target.value)}
-            required
-          />
+          <input type="number" step="0.1" value={weight} onChange={(e) => setWeight(e.target.value)} required />
         </div>
         <div>
           <label>📉 Fat Percentage (%):</label>
-          <input
-            type="number"
-            step="0.1"
-            value={fatpercentage}
-            onChange={(e) => setFatPercentage(e.target.value)}
-            required
-          />
+          <input type="number" step="0.1" value={fatpercentage} onChange={(e) => setFatPercentage(e.target.value)} required />
         </div>
         <button type="submit">✅ Submit</button>
       </form>
-
-      {/* 사용자가 입력한 정보 및 결과 출력 */}
-      {bmi !== null && inbodyScore !== null && (
-        <div>
-          <h2>📊 InBody 결과</h2>
-          <p>
-            <strong>📏 키:</strong> {height} cm
-          </p>
-          <p>
-            <strong>⚖️ 몸무게:</strong> {weight} kg
-          </p>
-          <p>
-            <strong>📉 체지방률 :</strong> {fatpercentage} %
-          </p>
-          <p>
-            <strong>💪 BMI:</strong> {bmi.toFixed(2)}
-          </p>
-          <p>
-            <strong>🔥 InBody Score:</strong> {inbodyScore.toFixed(2)}
-          </p>
-        </div>
-      )}
     </div>
   );
 }

--- a/react/protoInbodyReact-main/src/Component/TodoCalender.js
+++ b/react/protoInbodyReact-main/src/Component/TodoCalender.js
@@ -5,59 +5,60 @@ import config from "../config";
 export default function TodoCalender() {
   const navigate = useNavigate();
   const [userData, setUserData] = useState([]);
-
-  // sessionStorage에서 JWT 토큰를 가져옵니다.
-  const token = sessionStorage.getItem("token");
-  const userid = sessionStorage.getItem("userid");
+  const [userid, setUserid] = useState("");
 
   useEffect(() => {
-    if (token) {
-      fetch(`http://${config.SERVER_URL}/request/diet-records/${userid}`, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
+    // 서버에서 현재 로그인한 사용자 확인
+    fetch(`http://${config.SERVER_URL}/request/validate`, {
+      method: "GET",
+      credentials: "include",
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error("Unauthorized");
+        return response.json();
       })
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error("서버 응답이 실패했습니다.");
-          }
-          return response.json();
-        })
-        .then((data) => {
-          console.log("받은 데이터:", data);
-          setUserData(data);
-        })
-        .catch((error) => console.error("데이터 불러오기 실패:", error));
-    }
-  }, [token]);
+      .then((data) => {
+        console.log("로그인 상태 확인 성공:", data);
+        setUserid(data.userid);
 
-  const navigateToFood = () => {
-    navigate("/food");
-  };
+        // 식단 기록 가져오기
+        return fetch(`http://${config.SERVER_URL}/request/diet-records/${data.userid}`, {
+          method: "GET",
+          credentials: "include", // 쿠키 포함 요청
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+      })
+      .then((response) => {
+        if (!response.ok) throw new Error("서버 응답이 실패했습니다.");
+        return response.json();
+      })
+      .then((data) => {
+        console.log("받은 데이터:", data);
+        setUserData(data);
+      })
+      .catch((error) => {
+        console.warn("인증 실패 또는 데이터 불러오기 실패:", error);
+        navigate("/login");
+      });
+  }, [navigate]);
 
   return (
     <div>
       <h2>내 식단 기록</h2>
 
-      {userData && userData.length > 0 ? (
+      {userData.length > 0 ? (
         userData.map((record, index) => (
           <div key={index}>
-            <p> 메모: {record.dietMemo || "메모 없음"}</p>
-            <p>
-              날짜:{" "}
-              {record.timestamp
-                ? new Date(record.timestamp).toLocaleDateString("ko-KR")
-                : "날짜 없음"}
-            </p>
-            <p> 음식: {record.foodNm || "음식 없음"}</p>
-            <p> 칼로리: {record.enerc || 0} kcal</p>
-            <p> 단백질: {record.prot || 0}g</p>
-            <p> 탄수화물: {record.chocdf || 0}g</p>
-            <p> 지방: {record.fatce || 0}g</p>
-            <p> 제조사: {record.mfrNm || 0}g</p>
-
+            <p>메모: {record.dietMemo || "메모 없음"}</p>
+            <p>날짜: {record.timestamp ? new Date(record.timestamp).toLocaleDateString("ko-KR") : "날짜 없음"}</p>
+            <p>음식: {record.foodNm || "음식 없음"}</p>
+            <p>칼로리: {record.enerc || 0} kcal</p>
+            <p>단백질: {record.prot || 0}g</p>
+            <p>탄수화물: {record.chocdf || 0}g</p>
+            <p>지방: {record.fatce || 0}g</p>
+            <p>제조사: {record.mfrNm || "정보 없음"}</p>
             <hr />
           </div>
         ))
@@ -65,7 +66,7 @@ export default function TodoCalender() {
         <p>기록이 없습니다.</p>
       )}
 
-      <button onClick={navigateToFood}>음식 검색</button>
+      <button onClick={() => navigate("/food")}>음식 검색</button>
     </div>
   );
 }

--- a/react/protoInbodyReact-main/src/config.js
+++ b/react/protoInbodyReact-main/src/config.js
@@ -1,5 +1,5 @@
 const config = {
-  SERVER_URL: "172.30.113.157:8080",
+  SERVER_URL: "123.215.51.252:8080",
 };
 
 export default config;

--- a/spring/protoInbody-main/src/main/java/com/example/demo/Jwt/JwtRequestFilter.java
+++ b/spring/protoInbody-main/src/main/java/com/example/demo/Jwt/JwtRequestFilter.java
@@ -1,5 +1,6 @@
 package com.example.demo.Jwt;
 
+import jakarta.servlet.http.Cookie;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -22,23 +23,34 @@ public class JwtRequestFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
 
-        final String authorizationHeader = request.getHeader("Authorization");
-
+        Cookie[] cookies = request.getCookies();
         String username = null;
         String jwt = null;
 
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            jwt = authorizationHeader.substring(7);
-            username = jwtUtil.extractUsername(jwt);
-        }
-
-        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            if (jwtUtil.validateToken(jwt, username)) {
-                UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
-                        username, null, new ArrayList<>());
-                SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                System.out.println("쿠키 이름: " + cookie.getName() + ", 값: " + cookie.getValue());
+                if ("jwt".equals(cookie.getName())) {
+                    jwt = cookie.getValue();
+                    username = jwtUtil.extractUsername(jwt);
+                    System.out.println("추출된 username: " + username);
+                    break;
+                }
             }
         }
+
+        if (jwt != null && username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            System.out.println("검증할 유저명: " + username);
+            if (jwtUtil.validateToken(jwt, username)) {
+                System.out.println("JWT 유효성 검사 통과!");
+                UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                        username, null, new ArrayList<>());
+                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+            } else {
+                System.out.println("JWT 유효성 검사 실패!");
+            }
+        }
+
         chain.doFilter(request, response);
     }
 }

--- a/spring/protoInbody-main/src/main/java/com/example/demo/Jwt/JwtUtil.java
+++ b/spring/protoInbody-main/src/main/java/com/example/demo/Jwt/JwtUtil.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 
 import java.util.Date;
@@ -13,20 +14,24 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class JwtUtil {
-
-    private Key secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS256); // 적절한 크기의 키 생성
+    private final String SECRET_KEY = "my_super_secret_key_which_is_at_least_32_chars_long"; // 반드시 32자 이상으로 설정
+    private final Key secretKey = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
 
     public String generateToken(String username) {
         return Jwts.builder()
                 .setSubject(username)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10)) // 10시간
-                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 3)) // 3시간 유효
+                .signWith(secretKey, SignatureAlgorithm.HS256) // 올바른 서명 방식 적용
                 .compact();
     }
 
     public boolean validateToken(String token, String username) {
-        return (username.equals(extractUsername(token)) && !isTokenExpired(token));
+        String extractedUsername = extractUsername(token);
+        System.out.println("JWT에서 추출된 유저명: " + extractedUsername);
+        System.out.println("비교할 유저명: " + username);
+
+        return (extractedUsername != null && extractedUsername.equals(username) && !isTokenExpired(token));
     }
 
     public String extractUsername(String token) {
@@ -34,7 +39,11 @@ public class JwtUtil {
     }
 
     private Claims extractClaims(String token) {
-        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey) // setSigningKey() 수정
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
     }
 
     private boolean isTokenExpired(String token) {

--- a/spring/protoInbody-main/src/main/java/com/example/demo/SecurityConfig.java
+++ b/spring/protoInbody-main/src/main/java/com/example/demo/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/request/login").permitAll()
                         .requestMatchers("/upload/register").permitAll()
+                        .requestMatchers("/download/**").authenticated()  //
                         .anyRequest().authenticated())
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 


### PR DESCRIPTION
- JWT 인증방식을 sessionStorage → HttpOnly Secure Cookie로 변경하여 자바스크립트로 접근 불가하게 XSS 공격 방지
- 모든 API요청에서 credentials: "include" 설정하여 브라우저가 JWT 쿠키를 자동 포함
- sessionStorage에 userid를 저장하면 조작가능하기 떄문에 /request/validate 엔드포인트 추가하여 jwt가 유효한지 서버에서 확인
- React의 sessionStorage.getItem("token") 방식 제거 후, documnet.cookie로 JWT 쿠키 존재여부 확인후 /request/validate로 서버에서 인증 확인함
- 일부 API가 문자열 반환시 .json()에서 파싱오류 발생해서 응답을 먼저 .text()로 받고 JSON 형식이면 JSON.parse()로 변환